### PR TITLE
add read_asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ Net.remove_asset(server_path)
 Net.has_asset(server_path)
 Net.get_asset_type(server_path)
 Net.get_asset_size(server_path)
+Net.read_asset(server_path) -- returns asset content as string (text assets) or base64 string (binary assets)
 ```
 
 ### Async API

--- a/src/plugins/lua/api/asset_api.rs
+++ b/src/plugins/lua/api/asset_api.rs
@@ -65,4 +65,24 @@ pub fn inject_dynamic(lua_api: &mut LuaApi) {
       lua_ctx.pack_multi(0)
     }
   });
+
+  lua_api.add_dynamic_function("Net", "read_asset", |api_ctx, lua_ctx, params| {
+    let path: mlua::String = lua_ctx.unpack_multi(params)?;
+    let path_str = path.to_str()?;
+    let net = api_ctx.net_ref.borrow();
+
+    if let Some(asset) = net.get_asset(path_str) {
+      match &asset.data {
+        AssetData::Text(text) => lua_ctx.pack_multi(text.clone()),
+        AssetData::Data(bytes)
+        | AssetData::Texture(bytes)
+        | AssetData::Audio(bytes) => {
+          let encoded = base64::encode(bytes);
+          lua_ctx.pack_multi(encoded)
+        }
+      }
+    } else {
+      lua_ctx.pack_multi(mlua::Value::Nil)
+    }
+  });
 }


### PR DESCRIPTION
To support navispots on net city I needed to add a read_asset command to get the raw data of assets that only exist in the servers virtual /server directory.

I've tested it for images and text, but I'm new to rust so you might want to review this one.